### PR TITLE
Rename bcgov/indy-catalyst to hyperledger/aries-vcr

### DIFF
--- a/openshift/bc-oil-gas-agent-build.param
+++ b/openshift/bc-oil-gas-agent-build.param
@@ -6,7 +6,7 @@
 NAME=bc-oil-gas-agent
 APP_NAME=bc-oil-and-gas-agent
 APP_GROUP=bc-oil-and-gas-agent
-GIT_REPO_URL=https://github.com/bcgov/indy-catalyst.git
+GIT_REPO_URL=https://github.com/hyperledger/aries-vcr.git
 GIT_REF=master
 SOURCE_CONTEXT_DIR=docker/tob-agent
 OUTPUT_IMAGE_TAG=latest

--- a/openshift/templates/agent/bc-oil-gas-agent-build.json
+++ b/openshift/templates/agent/bc-oil-gas-agent-build.json
@@ -95,7 +95,7 @@
       "displayName": "Git Repo URL",
       "description": "The URL to your GIT repo.",
       "required": true,
-      "value": "https://github.com/bcgov/indy-catalyst.git"
+      "value": "https://github.com/hyperledger/aries-vcr.git"
     },
     {
       "name": "GIT_REF",


### PR DESCRIPTION
- indy-catalyst is being renamed to aries-vcr and being contributed to Hyperledger
- https://github.com/bcgov/aries-vcr/issues/464

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>